### PR TITLE
Remove back button from sign in and remove warning

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,6 +1,7 @@
-import { getAuth } from "@firebase/auth"
+import { initializeAuth, getReactNativePersistence } from "@firebase/auth"
 import { initializeApp } from "@firebase/app"
 import { getFirestore } from "@firebase/firestore"
+import ReactNativeAsyncStorage from '@react-native-async-storage/async-storage';
 import {
   API_KEY,
   AUTH_DOMAIN,
@@ -21,4 +22,6 @@ const firebaseConfig = {
 
 export const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
-export const auth = getAuth(app)
+export const auth = initializeAuth(app, {
+  persistence: getReactNativePersistence(ReactNativeAsyncStorage)
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.0",
+        "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-navigation/native": "^6.0.2",
         "expo": "~50.0.8",
         "expo-font": "~11.10.3",
@@ -4953,6 +4954,17 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
+      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -14524,6 +14536,25 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^6.0.2",
     "expo": "~50.0.8",
     "expo-font": "~11.10.3",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -61,6 +61,7 @@ function RootLayoutNav() {
     <ThemeProvider value={MyTheme}>
       <LoaderProvider>
         <Stack>
+          <Stack.Screen name="index" options={{ headerShown: false }} />
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         </Stack>
       </LoaderProvider>


### PR DESCRIPTION
This PR is directed to KAN-17 branch because I used it as a reference for newest changes.
It should not be merged into main before KAN-17.

Resolved warning `Auth state should be saved to async storage in order to make loggin in not mandatory after restarting the app. Use async-storage package (screenshot down below).`

Removed back button from sign in page
![image](https://github.com/ISI-dotnet/notes-app/assets/100164021/89a60af0-451a-43c7-86cf-4b6b453fd9c3)
