### PR TITLE
Kan 15 add toast messages where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-system-ui": "~2.9.3",
         "expo-web-browser": "~12.8.2",
         "firebase": "^10.9.0",
+        "html-to-text": "^9.0.5",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -7502,6 +7503,18 @@
         "join-component": "^1.1.0"
       }
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -9675,6 +9688,30 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -9686,6 +9723,33 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -9751,7 +9815,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -10993,6 +11056,39 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -14000,6 +14096,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15763,6 +15867,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -15869,6 +15985,14 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -17266,6 +17390,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-native-pell-rich-editor": "^1.9.0",
         "react-native-safe-area-context": "4.8.2",
         "react-native-screens": "~3.29.0",
+        "react-native-toast-message": "^2.2.0",
         "react-native-web": "~0.19.6"
       },
       "devDependencies": {
@@ -16677,6 +16678,15 @@
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.2.0.tgz",
+      "integrity": "sha512-AFti8VzUk6JvyGAlLm9/BknTNDXrrhqnUk7ak/pM7uCTxDPveAu2ekszU0on6vnUPFnG04H/QfYE2IlETqeaWw==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-system-ui": "~2.9.3",
     "expo-web-browser": "~12.8.2",
     "firebase": "^10.9.0",
+    "html-to-text": "^9.0.5",
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-pell-rich-editor": "^1.9.0",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
+    "react-native-toast-message": "^2.2.0",
     "react-native-web": "~0.19.6"
   },
   "devDependencies": {

--- a/src/app/(app)/(tabs)/_layout.tsx
+++ b/src/app/(app)/(tabs)/_layout.tsx
@@ -24,6 +24,7 @@ const TabLayout = () => {
       <Tabs.Screen
         name="index"
         options={{
+          headerShown: false,
           title: "Home",
           tabBarIcon: ({ color }) => (
             <Feather size={24} name="home" color={color} />
@@ -57,11 +58,13 @@ const TabLayout = () => {
       <Tabs.Screen
         name="user"
         options={{
-          headerShown: false,
           title: "User",
+
           tabBarIcon: ({ color }) => (
             <Feather name="heart" size={24} color={color} />
           ),
+          headerStyle: { backgroundColor: "orange" },
+          headerTitle: "Profile",
         }}
       />
     </Tabs>

--- a/src/app/(app)/(tabs)/user.tsx
+++ b/src/app/(app)/(tabs)/user.tsx
@@ -1,7 +1,12 @@
 import { auth } from "@/firebaseConfig"
 import { useSession } from "@/src/context/useSession"
-import { Button, Text, StyleSheet } from "react-native"
+import { Text, TouchableOpacity, View } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
+import { MaterialIcons } from "@expo/vector-icons"
+import { toastFirebaseErrors } from "@/src/utils/toastFirebaseErrors"
+import { showToast } from "@/src/utils/showToast"
+import { UNKNOWN_ERROR_MESSAGE } from "@/src/constants/ErrorMessages"
+import { Stack } from "expo-router"
 
 const UserPage = () => {
   const { signOut } = useSession()
@@ -9,65 +14,35 @@ const UserPage = () => {
   const user = auth.currentUser
 
   const handleLogOut = async () => {
-    try {
-      await signOut()
-    } catch (error) {
-      console.error("Authentication error:", error.message)
-    }
+    await signOut()
+      .then(() =>
+        showToast("success", "You are now logged out!", undefined, 4000)
+      )
+      .catch((error) => {
+        if (error.message) {
+          toastFirebaseErrors(error.message)
+        } else {
+          showToast("error", UNKNOWN_ERROR_MESSAGE)
+        }
+      })
   }
 
   return (
-    <SafeAreaView className="flex-1">
-      <Text style={styles.title}>Welcome</Text>
-      <Text style={styles.emailText}>{user?.email}</Text>
-      <Button title="Logout" onPress={handleLogOut} color="#e74c3c" />
+    <SafeAreaView className="flex-1 px-16">
+      <View className="items-center">
+        <MaterialIcons name="account-circle" size={100} color="grey" />
+      </View>
+      <Text className="mb-10 mt-2 text-center font-semibold text-lg">
+        {user?.email}
+      </Text>
+      <TouchableOpacity
+        onPress={handleLogOut}
+        className="bg-red-500 h-12 rounded-md justify-center items-center shadow-sm shadow-black"
+      >
+        <Text className="text-base text-white uppercase">logout</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   )
 }
 
 export default UserPage
-
-const styles = StyleSheet.create({
-  container: {
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 16,
-    backgroundColor: "#f0f0f0",
-  },
-  authContainer: {
-    width: "80%",
-    maxWidth: 400,
-    backgroundColor: "#fff",
-    padding: 16,
-    borderRadius: 8,
-    elevation: 3,
-  },
-  title: {
-    fontSize: 24,
-    marginBottom: 16,
-    textAlign: "center",
-  },
-  input: {
-    height: 40,
-    borderColor: "#ddd",
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 8,
-    borderRadius: 4,
-  },
-  buttonContainer: {
-    marginBottom: 16,
-  },
-  toggleText: {
-    color: "#3498db",
-    textAlign: "center",
-  },
-  bottomContainer: {
-    marginTop: 20,
-  },
-  emailText: {
-    fontSize: 18,
-    textAlign: "center",
-    marginBottom: 20,
-  },
-})

--- a/src/app/(app)/note/[id].tsx
+++ b/src/app/(app)/note/[id].tsx
@@ -21,6 +21,7 @@ import { useNavigation } from "expo-router"
 import { toastFirebaseErrors } from "@/src/utils/toastFirebaseErrors"
 import { showToast } from "@/src/utils/showToast"
 import { UNKNOWN_ERROR_MESSAGE } from "@/src/constants/ErrorMessages"
+import { convertToPlainText } from "@/src/utils/convertToPlainText"
 
 const NotePage = () => {
   const { id }: { id: string } = useLocalSearchParams()
@@ -32,6 +33,7 @@ const NotePage = () => {
     userId: session!,
     title: "",
     description: "",
+    richTextDescription: "",
     parentFolderName: "Home",
     parentFolderId: "home",
   })
@@ -47,6 +49,9 @@ const NotePage = () => {
       showToast("info", "Note can't be saved without a title")
       return
     }
+    noteDetails.description = convertToPlainText(
+      noteDetails.richTextDescription
+    )
     if (id !== "0") {
       const updatedNote = { id: id, ...noteDetails }
       updateNote(updatedNote)
@@ -165,13 +170,13 @@ const NotePage = () => {
               handleChange={(descriptionText) =>
                 setNoteDetails((oldValue) => ({
                   ...oldValue,
-                  description: descriptionText,
+                  richTextDescription: descriptionText,
                 }))
               }
               ref={richText}
               setIsFocused={setIsFocused}
               handleScroll={handleScroll}
-              noteDescription={noteDetails.description}
+              noteDescription={noteDetails.richTextDescription}
             />
           </KeyboardAvoidingView>
         </ScrollView>

--- a/src/app/(app)/note/[id].tsx
+++ b/src/app/(app)/note/[id].tsx
@@ -42,8 +42,11 @@ const NotePage = () => {
   const [isFocused, setIsFocused] = useState(false)
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
 
-  // TODO: handle errors with toast, modal or smth
   const handleSubmit = () => {
+    if (noteDetails.title === "") {
+      showToast("info", "Note can't be saved without a title")
+      return
+    }
     if (id !== "0") {
       const updatedNote = { id: id, ...noteDetails }
       updateNote(updatedNote)
@@ -129,11 +132,12 @@ const NotePage = () => {
               size={24}
               color="black"
               onPress={handleSubmit}
+              style={{ opacity: noteDetails.title === "" ? 0.3 : 1 }}
             />
           ),
         }}
       />
-      {loading || (id !== "0" && noteDetails.title === "") ? (
+      {loading || (id !== "0" && noteDetails.dateCreated === undefined) ? (
         <Loader />
       ) : (
         <ScrollView

--- a/src/app/(app)/note/[id].tsx
+++ b/src/app/(app)/note/[id].tsx
@@ -18,6 +18,9 @@ import { useLoader } from "@/src/context/useLoader"
 import Loader from "@/src/components/Loader"
 import { useSession } from "@/src/context/useSession"
 import { useNavigation } from "expo-router"
+import { toastFirebaseErrors } from "@/src/utils/toastFirebaseErrors"
+import { showToast } from "@/src/utils/showToast"
+import { UNKNOWN_ERROR_MESSAGE } from "@/src/constants/ErrorMessages"
 
 const NotePage = () => {
   const { id }: { id: string } = useLocalSearchParams()
@@ -45,11 +48,23 @@ const NotePage = () => {
       const updatedNote = { id: id, ...noteDetails }
       updateNote(updatedNote)
         .then(() => router.back())
-        .catch((error) => console.log(error))
+        .catch((error) => {
+          if (error.message) {
+            toastFirebaseErrors(error.message)
+          } else {
+            showToast("error", UNKNOWN_ERROR_MESSAGE)
+          }
+        })
     } else {
       createNote(noteDetails)
         .then(() => router.back())
-        .catch((error) => console.log(error))
+        .catch((error) => {
+          if (error.message) {
+            toastFirebaseErrors(error.message)
+          } else {
+            showToast("error", UNKNOWN_ERROR_MESSAGE)
+          }
+        })
     }
   }
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@react-navigation/native"
 import { useEffect } from "react"
 import { useFonts } from "expo-font"
 import FontAwesome from "@expo/vector-icons/FontAwesome"
+import Toast from "react-native-toast-message"
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -56,6 +57,7 @@ function Root() {
       <LoaderProvider>
         <ThemeProvider value={MyTheme}>
           <Slot />
+          <Toast topOffset={60} />
         </ThemeProvider>
       </LoaderProvider>
     </SessionProvider>

--- a/src/app/sign-in.tsx
+++ b/src/app/sign-in.tsx
@@ -2,15 +2,12 @@ import {
   ScrollView,
   TextInput,
   View,
-  StyleSheet,
   Text,
-  Button,
   TouchableOpacity,
 } from "react-native"
 import { useSession } from "../context/useSession"
 import { useState } from "react"
 import { useRouter } from "expo-router"
-import Toast from "react-native-toast-message"
 import { showToast } from "../utils/showToast"
 import { auth } from "@/firebaseConfig"
 import { toastFirebaseErrors } from "../utils/toastFirebaseErrors"

--- a/src/app/sign-in.tsx
+++ b/src/app/sign-in.tsx
@@ -5,10 +5,19 @@ import {
   StyleSheet,
   Text,
   Button,
+  TouchableOpacity,
 } from "react-native"
 import { useSession } from "../context/useSession"
 import { useState } from "react"
 import { useRouter } from "expo-router"
+import Toast from "react-native-toast-message"
+import { showToast } from "../utils/showToast"
+import { auth } from "@/firebaseConfig"
+import { toastFirebaseErrors } from "../utils/toastFirebaseErrors"
+import { UNKNOWN_ERROR_MESSAGE } from "../constants/ErrorMessages"
+import { COLORS } from "../constants/Colors"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { SimpleLineIcons } from "@expo/vector-icons"
 
 const SignInPage = () => {
   const { signIn, signUp } = useSession()
@@ -17,103 +26,109 @@ const SignInPage = () => {
   const [password, setPassword] = useState("")
   const [isLogin, setIsLogin] = useState(true)
 
+  const handleInputType = () => {
+    setIsLogin(!isLogin)
+    setEmail("")
+    setPassword("")
+  }
+
   const handleAuthentication = async () => {
-    try {
-      if (isLogin) {
-        // Sign in
-        await signIn(email, password)
-        router.navigate("/(tabs)/")
-      } else {
-        // Sign up
-        await signUp(email, password)
-        setIsLogin(true)
-      }
-    } catch (error) {
-      console.error("Authentication error:", error.message)
+    if (isLogin) {
+      // Sign in
+      await signIn(email, password)
+        .then(() => {
+          router.navigate("/(tabs)/")
+          showToast(
+            "success",
+            `Welcome back, ${auth.currentUser?.email} 👋`,
+            undefined,
+            4000
+          )
+        })
+        .catch((error) => {
+          if (error.message) {
+            toastFirebaseErrors(error.message)
+          } else {
+            showToast("error", UNKNOWN_ERROR_MESSAGE)
+          }
+        })
+    } else {
+      // Sign up
+      await signUp(email, password)
+        .then((event) => {
+          showToast(
+            "success",
+            "User created successfully! You can click SIGN IN."
+          )
+          setIsLogin(true)
+        })
+        .catch((error) => {
+          if (error.message) {
+            toastFirebaseErrors(error.message)
+          } else {
+            showToast("error", UNKNOWN_ERROR_MESSAGE)
+          }
+        })
     }
   }
+
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <View style={styles.authContainer}>
-        <Text style={styles.title}>{isLogin ? "Sign In" : "Sign Up"}</Text>
+    <SafeAreaView className="flex-1 justify-center mb-10">
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: "center",
+          paddingLeft: 64,
+          paddingRight: 64,
+        }}
+      >
+        <View className="items-center mb-10">
+          <SimpleLineIcons name="note" size={80} color={COLORS.darkOrange} />
+        </View>
+
+        <Text className="mb-8 text-2xl text-center font-medium">
+          {isLogin ? "Welcome back." : "Sign Up"}
+        </Text>
         <TextInput
-          style={styles.input}
+          className="h-12 border border-gray-300 mb-4 px-2 rounded-md"
           value={email}
           onChangeText={setEmail}
           placeholder="Email"
           autoCapitalize="none"
         />
         <TextInput
-          style={styles.input}
+          className="h-12 border border-gray-300 mb-4 px-2 rounded-md"
           value={password}
           onChangeText={setPassword}
           placeholder="Password"
           secureTextEntry
         />
-        <View style={styles.buttonContainer}>
-          <Button
-            title={isLogin ? "Sign In" : "Sign Up"}
-            onPress={handleAuthentication}
-            color="#3498db"
-          />
-        </View>
+        <TouchableOpacity
+          className={`mt-4 bg-orange-400 ${
+            email === "" || password === "" ? "opacity-70" : ""
+          } h-12 rounded-md justify-center items-center shadow-sm shadow-black`}
+          disabled={email === "" || password === ""}
+          onPress={handleAuthentication}
+        >
+          <Text className="text-base font- text-white uppercase">
+            {isLogin ? "Sign In" : "Sign Up"}
+          </Text>
+        </TouchableOpacity>
 
-        <View style={styles.bottomContainer}>
-          <Text style={styles.toggleText} onPress={() => setIsLogin(!isLogin)}>
-            {isLogin
-              ? "Need an account? Sign Up"
-              : "Already have an account? Sign In"}
+        <View className="mt-4">
+          <Text className="text-center">
+            {isLogin ? "Need an account? " : "Already have an account? "}
+            <Text
+              className="underline text-orange-500"
+              onPress={handleInputType}
+            >
+              {isLogin ? "Sign Up" : "Sign In"}
+            </Text>
           </Text>
         </View>
-      </View>
-    </ScrollView>
+      </ScrollView>
+    </SafeAreaView>
   )
 }
 
 export default SignInPage
-
-const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 16,
-    backgroundColor: "#f0f0f0",
-  },
-  authContainer: {
-    width: "80%",
-    maxWidth: 400,
-    backgroundColor: "#fff",
-    padding: 16,
-    borderRadius: 8,
-    elevation: 3,
-  },
-  title: {
-    fontSize: 24,
-    marginBottom: 16,
-    textAlign: "center",
-  },
-  input: {
-    height: 40,
-    borderColor: "#ddd",
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 8,
-    borderRadius: 4,
-  },
-  buttonContainer: {
-    marginBottom: 16,
-  },
-  toggleText: {
-    color: "#3498db",
-    textAlign: "center",
-  },
-  bottomContainer: {
-    marginTop: 20,
-  },
-  emailText: {
-    fontSize: 18,
-    textAlign: "center",
-    marginBottom: 20,
-  },
-})

--- a/src/components/fileList/FileList.tsx
+++ b/src/components/fileList/FileList.tsx
@@ -11,6 +11,9 @@ import EmptyFolder from "./EmptyFolder"
 import { useLoader } from "@/src/context/useLoader"
 import Loader from "../Loader"
 import { useSession } from "@/src/context/useSession"
+import { showToast } from "@/src/utils/showToast"
+import { toastFirebaseErrors } from "@/src/utils/toastFirebaseErrors"
+import { UNKNOWN_ERROR_MESSAGE } from "@/src/constants/ErrorMessages"
 
 const FileList = () => {
   const { currentFolderId } = useLocalSearchParams()
@@ -31,8 +34,12 @@ const FileList = () => {
 
         // Update fileList state after both promises have resolved
         setFileList([...foldersArr, ...notesArr])
-      } catch (error) {
-        console.error("Error fetching data:", error)
+      } catch (error: any) {
+        if (error.message) {
+          toastFirebaseErrors(error.message)
+        } else {
+          showToast("error", UNKNOWN_ERROR_MESSAGE)
+        }
       } finally {
         setIsLoading(false)
       }

--- a/src/constants/ErrorMessages.ts
+++ b/src/constants/ErrorMessages.ts
@@ -1,0 +1,1 @@
+export const UNKNOWN_ERROR_MESSAGE = "Unknown error occurred..."

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -54,7 +54,6 @@ export function SessionProvider(props: PropsWithChildren) {
       if (session) {
         // If user is already authenticated, log out
         await firebaseSignOut(auth)
-        console.log("User logged out successfully!")
         setSession(null)
         router.replace("/")
       }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -37,16 +37,15 @@ export function SessionProvider(props: PropsWithChildren) {
         throw new Error("Couldn't get user info, please try again.")
       }
     } catch (error) {
-      console.error("Sign-in error:", error.message)
+      throw error
     }
   }
 
   const signUp = async (email: string, password: string) => {
     try {
       await createUserWithEmailAndPassword(auth, email, password)
-      console.log("User created successfully!")
     } catch (error) {
-      console.error("Sign-in error:", error.message)
+      throw error
     }
   }
 
@@ -60,7 +59,7 @@ export function SessionProvider(props: PropsWithChildren) {
         router.replace("/")
       }
     } catch (error) {
-      console.error("Authentication error:", error.message)
+      throw error
     }
   }
 

--- a/src/types/Note.ts
+++ b/src/types/Note.ts
@@ -3,6 +3,7 @@ export type Note = {
   userId: string
   title: string
   description: string
+  richTextDescription: string
   parentFolderId: string
   parentFolderName: string
   dateCreated?: Date

--- a/src/utils/convertToPlainText.ts
+++ b/src/utils/convertToPlainText.ts
@@ -1,0 +1,5 @@
+const { convert } = require("html-to-text")
+
+export const convertToPlainText = (richText: string) => {
+  return convert(richText)
+}

--- a/src/utils/showToast.ts
+++ b/src/utils/showToast.ts
@@ -1,0 +1,15 @@
+import Toast, { ToastType } from "react-native-toast-message"
+
+export const showToast = (
+  type: ToastType = "success",
+  mainText: string,
+  descriptionText?: string,
+  visibilityTime = 6000
+) => {
+  Toast.show({
+    type: type,
+    text1: mainText,
+    text2: descriptionText,
+    visibilityTime: visibilityTime,
+  })
+}

--- a/src/utils/toastFirebaseErrors.ts
+++ b/src/utils/toastFirebaseErrors.ts
@@ -1,7 +1,6 @@
 import { showToast } from "./showToast"
 
 export const toastFirebaseErrors = (errorMessage: string) => {
-  console.log(JSON.stringify(errorMessage))
   switch (errorMessage) {
     case "Firebase: Error (auth/invalid-email).":
       showToast("error", "Provided email is not valid", undefined)

--- a/src/utils/toastFirebaseErrors.ts
+++ b/src/utils/toastFirebaseErrors.ts
@@ -1,0 +1,24 @@
+import { showToast } from "./showToast"
+
+export const toastFirebaseErrors = (errorMessage: string) => {
+  console.log(JSON.stringify(errorMessage))
+  switch (errorMessage) {
+    case "Firebase: Error (auth/invalid-email).":
+      showToast("error", "Provided email is not valid", undefined)
+      break
+    case "Firebase: Error (auth/invalid-credential).":
+      showToast("error", "Incorrect user email or password", undefined)
+      break
+    case "Firebase: Password should be at least 6 characters (auth/weak-password).":
+      showToast("error", "Password should be at least 6 characters", undefined)
+      break
+    case "Firebase: Error (auth/email-already-in-use).":
+      showToast("error", "Provided email already taken", undefined)
+      break
+    case "User created successfully!":
+      showToast("success", "User created successfully!")
+    default:
+      showToast("error", "Oops, something went wrong...")
+      break
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,8 @@ module.exports = {
   theme: {
     extend: {},
   },
+  variants: {
+    opacity: ({ after }) => after(["disabled"]),
+  },
   plugins: [],
 }


### PR DESCRIPTION
Run `npm i` before `npm start` in order to install toast package. Only do this the first time, app is run as always with 1 command `npm start`.

Things done:
- Restyled login/signup screen, improved UX (disabled button when no input is present, clearing input when switching between sign up and sign in, prefilling sign up info after creating new account in sign in - user only has to click sign up then)
- Restyled user profile tab
- Added toast messages whenever it makes sense. You can find all their uses in app by searching in code for functions **toastFirebaseErrors** and **showToast**.

### My request is try to mess with the app and see if you can get toast saying **"Unknown error occurred..."** or **"Oops, something went wrong..."** and comment on how to reproduce it. I'll then add custom error messages, since firebase api doesn't provide status codes as response, only error messages. I had to make switch statement and write each handler for each error 💀.

<img width="223" alt="image" src="https://github.com/ISI-dotnet/notes-app/assets/99315244/e9b5a685-cc37-4b92-96a9-2a416fb888b0">
<img width="222" alt="image" src="https://github.com/ISI-dotnet/notes-app/assets/99315244/09954f8e-826d-4d5d-a42f-76167c5eb8b2">
<img width="238" alt="image" src="https://github.com/ISI-dotnet/notes-app/assets/99315244/494d311f-1ee5-46cf-b7a3-e8653200e31f">

